### PR TITLE
Show current media volume on the webpage

### DIFF
--- a/app/src/main/assets/webremotevolumecontrol_spa.html
+++ b/app/src/main/assets/webremotevolumecontrol_spa.html
@@ -43,10 +43,10 @@
             function asyncVolume(e) {
                 console.log(e.id);
                 const xhr = new XMLHttpRequest();
-	        xhr.onreadystatechange = function() {
+                xhr.onreadystatechange = function() {
                     if (xhr.readyState == XMLHttpRequest.DONE) {
                         const element = document.getElementById("current-volume");
-			element.innerHTML = xhr.responseText;
+                        element.innerHTML = xhr.responseText;
                     }
                 }
                 xhr.open("POST", "/" + e.id, true);

--- a/app/src/main/assets/webremotevolumecontrol_spa.html
+++ b/app/src/main/assets/webremotevolumecontrol_spa.html
@@ -42,7 +42,13 @@
         <script type="application/javascript">
             function asyncVolume(e) {
                 console.log(e.id);
-                var xhr = new XMLHttpRequest();
+                const xhr = new XMLHttpRequest();
+	        xhr.onreadystatechange = function() {
+                    if (xhr.readyState == XMLHttpRequest.DONE) {
+                        const element = document.getElementById("current-volume");
+			element.innerHTML = xhr.responseText;
+                    }
+                }
                 xhr.open("POST", "/" + e.id, true);
                 xhr.send();
                 return false;
@@ -53,6 +59,7 @@
     <div class="box" >
         <input type="image" name="volume-up" id="volume-up" value="volume-up" onclick="return asyncVolume(this);" src="/volume-up.png"/>
         <input type="image" name="volume-down" id="volume-down" value="volume-down"  onclick="return asyncVolume(this);" src="/volume-down.png" />
+	<p>Current volume <div id="current-volume"></div>%</p>
     </div>
     </body>
 </html>

--- a/app/src/main/java/com/tanaka42/webremotevolumecontrol/HttpServer.java
+++ b/app/src/main/java/com/tanaka42/webremotevolumecontrol/HttpServer.java
@@ -168,13 +168,18 @@ public class HttpServer extends Thread {
 
                         status_code = "200";
                         String requestedFile = "";
+                        String currentVolume = "";
 
                         switch (requestLocation) {
                             case "/volume-up":
                                 audioManager.adjustVolume(AudioManager.ADJUST_RAISE, AudioManager.FLAG_PLAY_SOUND);
+                                currentVolume = audioManager.getStreamVolume(AudioManager.STREAM_MUSIC).toString();
+                                content_type = "text/html";
                                 break;
                             case "/volume-down":
                                 audioManager.adjustVolume(AudioManager.ADJUST_LOWER, AudioManager.FLAG_PLAY_SOUND);
+                                currentVolume = audioManager.getStreamVolume(AudioManager.STREAM_MUSIC).toString();
+                                content_type = "text/html";
                                 break;
                             case "/volume-up.png":
                             case "/volume-down.png":
@@ -196,6 +201,9 @@ public class HttpServer extends Thread {
                             int size = fileStream.available();
                             buffer = new byte[size];
                             int readResult = fileStream.read(buffer);
+                        }
+                        if (!currentVolume.isEmpty()) {
+                            buffer = currentVolume.getBytes();
                         }
                         writeResponse(out, buffer.length + "", buffer, status_code, content_type);
                     }


### PR DESCRIPTION
These changes are about to add a current media volume (after pressing the button volume up/down).

I haven't tested it, I don't have the infrastructure, so I was thinking that you could help me here and tell if it works or not.

I'm not that familiar with Java, but my initial idea was to include the current media volume value already when generating the HTML, but it seems that you are not using any framework for this and I didn't want to write a gibberish code that would convert streams to strings, replace something and then back again to streams.